### PR TITLE
fix type of dir name, add support for u64/u2 softiec (v3.9 firmware a…

### DIFF
--- a/include/dir.h
+++ b/include/dir.h
@@ -41,7 +41,7 @@ typedef struct {
   /// 1 comma
   /// 5 characters ID
   /// NUL
-  unsigned char name[16+1+5+1];
+  char name[16+1+5+1];
   struct direlement * firstelement;
   struct direlement * selected;
   /// current cursor position

--- a/include/ops.h
+++ b/include/ops.h
@@ -50,7 +50,7 @@ void initDirWindowHeight(void);
 int textInput(const BYTE xpos, const BYTE ypos, char *str, const BYTE size);
 void doDOScommand(const BYTE context, const BYTE sorted, const BYTE use_linebuffer);
 
-enum drive_e {NONE=0, D1540, D1541, D1551, D1570, D1571, D1581, D1001, D2031, D8040, SD2IEC, CMD, VICE, LAST_DRIVE_E};
+enum drive_e {NONE=0, D1540, D1541, D1551, D1570, D1571, D1581, D1001, D2031, D8040, SD2IEC, CMD, VICE, U64, LAST_DRIVE_E};
 
 extern BYTE devicetype[];
 extern const char* drivetype[];

--- a/src/dc.c
+++ b/src/dc.c
@@ -1498,7 +1498,12 @@ doMakeImage(const BYTE device)
       return;
     }
 
-  sprintf(linebuffer, "%s,p", linebuffer2);
+  if (devicetype[device] == U64)
+    {
+      sprintf(linebuffer,"%s,s", linebuffer2);
+    } else {
+      sprintf(linebuffer, "%s,p", linebuffer2);
+    }
   if (cbm_open(7, device, CBM_WRITE, linebuffer) != 0)
     {
 #if !defined(__PET__)

--- a/src/ops.c
+++ b/src/ops.c
@@ -66,7 +66,7 @@ initDirWindowHeight(void)
 char DOSstatus[40];
 
 /// string descriptions of enum drive_e
-const char* drivetype[LAST_DRIVE_E] = {"", "1540", "1541", "1551", "1570", "1571", "1581", "1001", "2031", "8040", "sd2iec", "cmd", "vice"};
+const char* drivetype[LAST_DRIVE_E] = {"", "1540", "1541", "1551", "1570", "1571", "1581", "1001", "2031", "8040", "sd2iec", "cmd", "vice", "u64"};
 /// enum drive_e value for each device 0-11.
 BYTE devicetype[12];
 
@@ -609,7 +609,7 @@ changeDir(const BYTE context, const BYTE device, const char *dirname, const BYTE
         }
       if (mount ||
           (l == 1 && dirname[0]==CH_LARROW) ||
-          devicetype[device] == VICE)
+          devicetype[device] == VICE || devicetype[device] == U64)
         {
           sprintf(linebuffer, "cd:%s", dirname);
         }


### PR DESCRIPTION
U64/UII/UII+ soft iec devices act like a vice dir device, so added U64 to the recognized device types, and made changeDir use the proper cd command syntax. 

Additionally, unsigned char name in the directory struct fails to compile on my cc65 version, and seems incorrect. 