### PR TITLE
Add cbm_close command to fix file open error after error abort

### DIFF
--- a/src/ops.c
+++ b/src/ops.c
@@ -125,6 +125,7 @@ dosCommand(const BYTE lfn, const BYTE drive, const BYTE sec_addr, const char *cm
   int res;
   if (cbm_open(lfn, drive, sec_addr, cmd) != 0)
     {
+      cbm_close(lfn);
       return _oserror;
     }
 


### PR DESCRIPTION
I had issues with file open errors, which I could trace back to this function here not closing the logical file number after aborting with an OS error.

File open issues for me are solved with adding this cbm_close(lfn); line.